### PR TITLE
proper test for failed-open

### DIFF
--- a/pd/jsusfx_pd.cpp
+++ b/pd/jsusfx_pd.cpp
@@ -86,7 +86,7 @@ void jsusfx_compile(t_jsusfx *x, t_symbol *newFile) {
         char result[1024], *bufptr;
         result[0] = 0;
         int fd = open_via_path(x->canvasdir, newFile->s_name, "", result, &bufptr, 1024, 1);
-        if ( fd == 0 || result[0] == 0 ) {
+        if ( fd < 0 || result[0] == 0 ) {
             error("jsusfx~: unable to find script %s", newFile->s_name);
             return;
         }


### PR DESCRIPTION
open_via_path() will return "-1" (like open(2)) on failure, not 0

i guess this is the real reason for the crash #1 (when opening the file fails, you should never need to fallthru to the `result[0]==0` test).