### PR TITLE
Fixes for jsusfx_test on MacOS.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -9,17 +9,6 @@ OBJS2=
 UNAME_S := $(shell uname -s)
 
 ifeq ($(UNAME_S),Darwin)
-  ifdef ARCH
-    CFLAGS += -arch $(ARCH)
-  else
-    ARCH = i686
-    CFLAGS += -arch i686
-  endif
-else
-  ARCH := $(shell uname -m)
-endif
-
-ifeq ($(UNAME_S),Darwin)
 	# by default, we take for granted that OS X builds are FAT (i386 + x86_64)
 	OBJS2 += ../WDL/eel2/asm-nseel-x64-macho.o    
 endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -27,8 +27,6 @@ default: jsusfx_test
 ../WDL/eel2/asm-nseel-x64.o: 
 	cd ../WDL/eel2 && php a2x64.php elf64
 
-OBJS2 += ../WDL/eel2/asm-nseel-x64.o
-
 jsusfx_shared: 
 	cc jsusfx_shared.c -o jsusfx_shared -ldl
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,7 +1,7 @@
 CFLAGS=-O -g -fPIC -DWDL_FFT_REALSIZE=8 
 LFLAGS=-fPIC 
 #PORTABLE=true
-CXXFLAGS=-fPIC
+CXXFLAGS=-fPIC -DWDL_FFT_REALSIZE=8
 
 OBJS=../jsusfx.o ../WDL/eel2/nseel-compiler.o ../WDL/eel2/nseel-eval.o ../WDL/eel2/nseel-ram.o ../WDL/eel2/nseel-yylex.o ../WDL/eel2/nseel-cfunc.o  ../WDL/fft.o jsusfx_test.o
 OBJS2=
@@ -19,10 +19,24 @@ else
   ARCH := $(shell uname -m)
 endif
 
+ifeq ($(UNAME_S),Darwin)
+	# by default, we take for granted that OS X builds are FAT (i386 + x86_64)
+	OBJS2 += ../WDL/eel2/asm-nseel-x64-macho.o    
+endif
+ifeq ($(UNAME_S),Linux)
+	ifeq ($(ARCH),x86_64)
+	  OBJS2 += ../WDL/eel2/asm-nseel-x64.o
+	endif
+endif
+
 default: jsusfx_test
 
-#asm-nseel-x64.o: ../WDL/eel2/a2x64.php ../WDL/eel2/asm-nseel-x86-gcc.c
-#	php ../WDL/eel2/a2x64.php elf64
+# This is the assembly part that is only required for x64 ; php and nasm are required
+../WDL/eel2/asm-nseel-x64-macho.o: 
+	cd ../WDL/eel2 && php a2x64.php macho64x
+
+../WDL/eel2/asm-nseel-x64.o: 
+	cd ../WDL/eel2 && php a2x64.php elf64
 
 OBJS2 += ../WDL/eel2/asm-nseel-x64.o
 
@@ -43,3 +57,4 @@ testso: jsusfx_shared jsusfx_test.so
 
 clean:
 	rm -f jsusfx_test jsusfx_test.so jsusfx_shared
+	rm $(OBJS) $(OBJS2)

--- a/test/jsusfx_test.cpp
+++ b/test/jsusfx_test.cpp
@@ -18,7 +18,7 @@ public:
         vsnprintf(output, 4095, fmt, argptr);
         va_end(argptr);
 
-        printf(output);
+        printf("%s", output);
         printf("\n");
     }
 
@@ -29,13 +29,13 @@ public:
         vsnprintf(output, 4095, fmt, argptr);
         va_end(argptr);
 
-        printf(output);
+        printf("%s", output);
         printf("\n");
     }
 };
 
 
-void test_script(char *path) {
+void test_script(const char *path) {
 	JsusFxTest *fx;
     float *in[2];
     float *out[2];

--- a/test/jsusfx_test.cpp
+++ b/test/jsusfx_test.cpp
@@ -50,12 +50,16 @@ void test_script(const char *path) {
 	
 	std::ifstream is(path);
     
-	printf("compile %d: %s\n", fx->compile(is), path);
-    
-    fx->prepare(44100, 64);
-    fx->process(in, out, 64);
-    fx->dumpvars();
-	delete fx;
+    if (!is.is_open()) {
+        printf("failed to open jsfx file (%s)\n", path);
+    } else {
+    	printf("compile %d: %s\n", fx->compile(is), path);
+        
+        fx->prepare(44100, 64);
+        fx->process(in, out, 64);
+        fx->dumpvars();
+    	delete fx;
+    }
 }
 extern "C" void test_jsfx();
 

--- a/test/jsusfx_test.cpp
+++ b/test/jsusfx_test.cpp
@@ -65,7 +65,7 @@ extern "C" void test_jsfx();
 
 void test_jsfx() {
     JsusFx::init();
-    test_script("/home/asb2m10/src/jsusfx/pd/gain.jsfx");   
+    test_script("../pd/gain.jsfx");   
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
Hi,

I made various fixes to make jsusfx_test work on MacOS 10.13 / x64.

Aside from some Makefile fixes I also improved the test a bit, by using a relative path for the gain jsfx file and checking if the file open succeeded.