### PR TITLE
Extended sliders and getting more scripts to compile

### DIFF
--- a/jsusfx.cpp
+++ b/jsusfx.cpp
@@ -494,11 +494,9 @@ void JsusFx::draw() {
     NSEEL_code_execute(codeGfx);
 }
 
-const WDL_FastString * JsusFx::getString(const int index) {
+const char * JsusFx::getString(const int index, WDL_FastString ** fs) {
 	void * opaque = this;
-	WDL_FastString * result = nullptr;
-	EEL_STRING_GET_FOR_INDEX(index, &result);
-	return result;
+	return EEL_STRING_GET_FOR_INDEX(index, fs);
 }
 
 void JsusFx::releaseCode() {

--- a/jsusfx.cpp
+++ b/jsusfx.cpp
@@ -261,11 +261,25 @@ bool JsusFx::readSections(JsusFxPathLibrary &pathLibrary, const std::string &pat
                 int target = 0;
                 if ( ! sscanf(line, "slider%d:", &target) )
                     continue;
-                if ( target >= 64 ) 
+                if ( target < 0 || target >= 64 )
                     continue;
-                char *p = line+8;
-                if ( *p == ':' ) 
-                    p++;
+				
+                char *p = line+7;
+                while ( *p && *p != ':' )
+                	p++;
+                if ( *p != ':' )
+                	continue;
+				p++;
+					
+				if ( isalpha(*p) ) {
+					// extended syntax of format "slider1:variable_name=5<0,10,1>slider description"
+					// skip the variable_name= part here for now until we actually need it
+					while ( *p && *p != '=' )
+						p++;
+					if ( *p != '=' )
+						continue;
+					p++;
+				}
 
                 if ( ! sliders[target].config(p) ) {
                     displayError("Incomplete slider line %d", lnumber);

--- a/jsusfx.cpp
+++ b/jsusfx.cpp
@@ -99,6 +99,9 @@ JsusFx::JsusFx() {
     	*spl[i] = 0;
 	}
 	
+	numInputs = 0;
+	numOutputs = 0;
+	
 	numValidInputChannels = 0;
 	
     AUTOVAR(srate);
@@ -324,13 +327,13 @@ bool JsusFx::readSections(JsusFxPathLibrary &pathLibrary, const std::string &pat
                 trim(sliders[target].desc, false, true);
                 continue;
             }
-            if ( ! strncmp(line, "desc:", 5) ) {
+            else if ( ! strncmp(line, "desc:", 5) ) {
             	char *src = line+5;
             	src = trim(src, true, true);
                 strncpy(desc, src, 64);
                 continue;
             }
-            if ( ! strnicmp(line, "filename", 8) ) {
+            else if ( ! strnicmp(line, "filename:", 9) ) {
 				
             	// filename:0,filename.wav
 				
@@ -365,7 +368,7 @@ bool JsusFx::readSections(JsusFxPathLibrary &pathLibrary, const std::string &pat
 					}
 				}
             }
-            if ( ! strncmp(line, "import ", 5) ) {
+            else if ( ! strncmp(line, "import ", 5) ) {
 				char *src = line+7;
 				src = trim(src, true, true);
 					
@@ -373,6 +376,12 @@ bool JsusFx::readSections(JsusFxPathLibrary &pathLibrary, const std::string &pat
 					processImport(pathLibrary, path, src, sections);
 				}
                 continue;
+            }
+            else if ( ! strncmp(line, "in_pin: ", 7) ) {
+            	numInputs++;
+            }
+            else if ( ! strncmp(line, "out_pin: ", 8) ) {
+            	numOutputs++;
             }
         }
     }
@@ -555,9 +564,15 @@ void JsusFx::releaseCode() {
         
     codeInit = codeSlider = codeBlock = codeSample = codeGfx = NULL;
 
+	numInputs = 0;
+	numOutputs = 0;
+	
     for(int i=0;i<64;i++)
-        sliders[i].exists = false;
-
+    	sliders[i].exists = false;
+	
+	gfx_w = 0;
+	gfx_h = 0;
+	
     NSEEL_VM_remove_unused_vars(m_vm);
     NSEEL_VM_remove_all_nonreg_vars(m_vm);
 }

--- a/jsusfx.cpp
+++ b/jsusfx.cpp
@@ -105,7 +105,6 @@ bool JsusFx::compileSection(int state, const char *code, int line_offset) {
         if ( codeInit == NULL ) {
             snprintf(errorMsg, 4096, "@init line %s", NSEEL_code_getcodeerror(m_vm));
             displayError(errorMsg);
-            releaseCode();
             return false;
         }
         break;
@@ -114,7 +113,6 @@ bool JsusFx::compileSection(int state, const char *code, int line_offset) {
         if ( codeSlider == NULL ) {
             snprintf(errorMsg, 4096, "@slider line %s", NSEEL_code_getcodeerror(m_vm));
             displayError(errorMsg);
-            releaseCode();
             return false;
         }
         break;
@@ -123,7 +121,6 @@ bool JsusFx::compileSection(int state, const char *code, int line_offset) {
         if ( codeBlock == NULL ) {
             snprintf(errorMsg, 4096, "@block line %s", NSEEL_code_getcodeerror(m_vm));
             displayError(errorMsg);
-            releaseCode();
             return false;
         }
         break;
@@ -132,7 +129,6 @@ bool JsusFx::compileSection(int state, const char *code, int line_offset) {
         if ( codeSample == NULL ) {
             snprintf(errorMsg, 4096, "@sample line %s", NSEEL_code_getcodeerror(m_vm));
             displayError(errorMsg);
-            releaseCode();
             return false;
         }
         break;
@@ -145,7 +141,6 @@ bool JsusFx::compileSection(int state, const char *code, int line_offset) {
         if ( codeGfx == NULL ) {
             snprintf(errorMsg, 4096, "@gfx line %s", NSEEL_code_getcodeerror(m_vm));
             displayError(errorMsg);
-            releaseCode();
             return false;
         }
         break;
@@ -366,6 +361,9 @@ bool JsusFx::compileSections(JsusFx_Sections &sections) {
 		result &= compileSection(3, sections.sample.code.Get(), sections.sample.lineOffset);
 	if (sections.gfx.code.GetLength() != 0)
 		result &= compileSection(4, sections.gfx.code.Get(), sections.gfx.lineOffset);
+	
+	if (result == false)
+		releaseCode();
 	
 	return result;
 }

--- a/jsusfx.cpp
+++ b/jsusfx.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "jsusfx.h"
+#include "jsusfx_gfx.h"
 
 #include <string.h>
 #include <unistd.h>
@@ -278,6 +279,41 @@ bool JsusFx::readSections(JsusFxPathLibrary &pathLibrary, const std::string &pat
             	src = trim(src, true, true);
                 strncpy(desc, src, 64);
                 continue;
+            }
+            if ( ! strnicmp(line, "filename", 8) ) {
+				
+            	// filename:0,filename.wav
+				
+            	char *src = line+8;
+				
+            	src = trim(src, true, false);
+				
+            	if ( *src != ':' )
+            		return false;
+				src++;
+				
+				src = trim(src, true, false);
+				
+				int index;
+				if ( sscanf(src, "%d", &index) != 1 )
+					return false;
+				while ( isdigit(*src) )
+					src++;
+				
+				src = trim(src, true, false);
+				
+				if ( *src != ',' )
+					return false;
+				src++;
+				
+				src = trim(src, true, true);
+				
+				std::string resolvedPath;
+				if ( pathLibrary.resolveImportPath(src, path, resolvedPath) ) {
+					if ( gfx != nullptr && ! gfx->handleFile(index, resolvedPath.c_str() ) ) {
+						return false;
+					}
+				}
             }
             if ( ! strncmp(line, "import ", 5) ) {
 				char *src = line+7;

--- a/jsusfx.cpp
+++ b/jsusfx.cpp
@@ -368,7 +368,7 @@ bool JsusFx::readSections(JsusFxPathLibrary &pathLibrary, const std::string &pat
 					}
 				}
             }
-            else if ( ! strncmp(line, "import ", 5) ) {
+            else if ( ! strncmp(line, "import ", 7) ) {
 				char *src = line+7;
 				src = trim(src, true, true);
 					

--- a/jsusfx.h
+++ b/jsusfx.h
@@ -138,6 +138,16 @@ public:
 					
 					tmp = skipWhite(tmp);
 					
+					if ( !sscanf(tmp, "%f", &inc) )
+					{
+						//log("failed to read increment value");
+						//return false;
+						
+						inc = 0;
+					}
+					
+					tmp = nextToken(tmp);
+					
 					if ( *tmp == '{' )
 					{
 						isEnum = true;
@@ -171,14 +181,6 @@ public:
 						}
 						
 						tmp++;
-					}
-					else
-					{
-						if ( !sscanf(tmp, "%f", &inc) )
-						{
-							log("failed to read increment value");
-							return false;
-						}
 					}
 				}
 			}

--- a/jsusfx.h
+++ b/jsusfx.h
@@ -47,8 +47,9 @@ public:
 
     Slider() {
         def = min = max = inc = 0;
-        exists = false;
         desc[0] = 0;
+        exists = false;
+        owner = nullptr;
         isEnum = false;
     }
 
@@ -78,7 +79,10 @@ public:
         strncpy(buffer, param, 1024);
                 
         def = min = max = inc = 0;
-        exists = false;     
+        exists = false;
+		
+        enumNames.clear();
+        isEnum = false;
 
         const char *tmp = strchr(buffer, '>');
         if ( tmp != NULL ) {
@@ -258,6 +262,9 @@ public:
     EEL_F *srate, *num_ch, *samplesblock;
     EEL_F *spl[kMaxSamples], *trigger;
     EEL_F dummyValue;
+	
+    int numInputs;
+    int numOutputs;
     int numValidInputChannels;
 	
     JsusFxGfx *gfx;

--- a/jsusfx.h
+++ b/jsusfx.h
@@ -60,7 +60,70 @@ public:
         } else {
             desc[0] = 0;
         }
-        
+		
+	#if 1
+		tmp = buffer;
+		
+		while (*tmp && isspace(*tmp))
+			tmp++;
+		
+        if ( !sscanf(tmp, "%f", &def) )
+            return false;
+		
+		while (*tmp && *tmp != '<')
+			tmp++;
+		
+		while (*tmp && isspace(*tmp))
+			tmp++;
+		
+		if (*tmp == '<')
+		{
+			tmp++;
+			
+			while (*tmp && isspace(*tmp))
+				tmp++;
+			
+			if ( !sscanf(tmp, "%f", &min) )
+				return false;
+		
+			while (*tmp && *tmp != ',')
+				tmp++;
+			
+			if (*tmp == ',')
+			{
+				tmp++;
+				
+				while (*tmp && isspace(*tmp))
+					tmp++;
+				
+				if ( !sscanf(tmp, "%f", &max) )
+            		return false;
+				
+				while (*tmp && *tmp != ',' && *tmp != '{')
+					tmp++;
+				
+				if (*tmp == ',')
+				{
+					tmp++;
+		
+					while (*tmp && isspace(*tmp))
+						tmp++;
+					
+					if (*tmp == '{')
+					{
+						printf("found list!\n");
+						
+						inc = 1;
+					}
+					else
+					{
+						if ( !sscanf(tmp, "%f", &inc) )
+							return false;
+					}
+				}
+			}
+		}
+	#else
         tmp = strtok(buffer, "<,");
         if ( !sscanf(tmp, "%f", &def) )
             return false;
@@ -76,6 +139,7 @@ public:
         tmp = strtok(NULL, "<,");
         if ( tmp != NULL )
             sscanf(tmp, "%f", &inc);
+	#endif
 
         *owner = def;
         exists = true;

--- a/jsusfx.h
+++ b/jsusfx.h
@@ -230,7 +230,7 @@ public:
     void process64(double **input, double **output, int size);
     void draw();
 	
-    const WDL_FastString * getString(int index);
+    const char * getString(int index, WDL_FastString ** fs);
     
     virtual void displayMsg(const char *fmt, ...) = 0;
     virtual void displayError(const char *fmt, ...) = 0;

--- a/jsusfx.h
+++ b/jsusfx.h
@@ -246,6 +246,8 @@ protected:
     bool compileSections(JsusFx_Sections &sections);
 
 public:
+	static const int kNumSamples = 64;
+	
     NSEEL_VMCTX m_vm;
     Slider sliders[64];
     int normalizeSliders;
@@ -254,7 +256,8 @@ public:
     EEL_F *tempo, *play_state, *play_position, *beat_position, *ts_num, *ts_denom;
     EEL_F *ext_noinit, *ext_nodenorm, *pdc_delay, *pdc_bot_cd, *pdc_top_ch;
     EEL_F *srate, *num_ch, *samplesblock;
-    EEL_F *spl0, *spl1, *trigger;
+    EEL_F *spl[kNumSamples], *trigger;
+    EEL_F dummyValue;
 	
     JsusFxGfx *gfx;
     int gfx_w;

--- a/jsusfx.h
+++ b/jsusfx.h
@@ -30,14 +30,18 @@
 
 class eel_string_context_state;
 
+class JsusFx;
 struct JsusFxGfx;
 
 class WDL_FastString;
 
-class Slider {
+class JsusFx_Slider {
 public:
+	static const int kMaxName = 63;
+	
     float def, min, max, inc;
 
+	char name[kMaxName + 1];
     char desc[64];
     EEL_F *owner;
     bool exists;
@@ -45,8 +49,9 @@ public:
     std::vector<std::string> enumNames;
     bool isEnum;
 
-    Slider() {
+    JsusFx_Slider() {
         def = min = max = inc = 0;
+        name[0] = 0;
         desc[0] = 0;
         exists = false;
         owner = nullptr;
@@ -74,127 +79,8 @@ public:
     	printf("%s\n", text);
 	}
 
-    bool config(char *param) {
-        char buffer[1024];
-        strncpy(buffer, param, 1024);
-                
-        def = min = max = inc = 0;
-        exists = false;
-		
-        enumNames.clear();
-        isEnum = false;
-
-        const char *tmp = strchr(buffer, '>');
-        if ( tmp != NULL ) {
-        	tmp++;
-        	while (*tmp == ' ')
-        		tmp++;
-            strncpy(desc, tmp, 64);
-            tmp = 0;
-        } else {
-            desc[0] = 0;
-        }
-		
-		tmp = buffer;
-		
-        if ( !sscanf(tmp, "%f", &def) )
-            return false;
-		
-		tmp = nextToken(tmp);
-		
-		if ( *tmp != '<' )
-		{
-			log("slider info is missing");
-			return false;
-		}
-		else
-		{
-			tmp++;
-			
-			if ( !sscanf(tmp, "%f", &min) )
-			{
-				log("failed to read min value");
-				return false;
-			}
-		
-			tmp = nextToken(tmp);
-			
-			if ( *tmp != ',' )
-			{
-				log("max value is missing");
-				return false;
-			}
-			else
-			{
-				tmp++;
-				
-				if ( !sscanf(tmp, "%f", &max) )
-				{
-					log("failed to read max value");
-            		return false;
-				}
-				
-				tmp = nextToken(tmp);
-				
-				if ( *tmp == ',')
-				{
-					tmp++;
-					
-					tmp = skipWhite(tmp);
-					
-					if ( !sscanf(tmp, "%f", &inc) )
-					{
-						//log("failed to read increment value");
-						//return false;
-						
-						inc = 0;
-					}
-					
-					tmp = nextToken(tmp);
-					
-					if ( *tmp == '{' )
-					{
-						isEnum = true;
-						
-						inc = 1;
-						
-						tmp++;
-						
-						while ( true )
-						{
-							const char *end = nextToken(tmp);
-							
-							const std::string name(tmp, end);
-							
-							enumNames.push_back(name);
-							
-							tmp = end;
-							
-							if ( *tmp == 0 )
-							{
-								log("enum value list not properly terminated");
-							 	return false;
-							}
-							
-							if ( *tmp == '}' )
-							{
-								break;
-							}
-							
-							tmp++;
-						}
-						
-						tmp++;
-					}
-				}
-			}
-		}
-
-        *owner = def;
-        exists = true;
-        return true;
-    }
-
+    bool config(JsusFx &fx, const int index, const char *param, const int lnumber);
+    
     /**
      * Return true if the value has changed
      */
@@ -251,9 +137,10 @@ protected:
 
 public:
 	static const int kMaxSamples = 64;
+	static const int kMaxSliders = 64;
 	
     NSEEL_VMCTX m_vm;
-    Slider sliders[64];
+    JsusFx_Slider sliders[kMaxSliders];
     int normalizeSliders;
     char desc[64];
     

--- a/jsusfx.h
+++ b/jsusfx.h
@@ -246,7 +246,7 @@ protected:
     bool compileSections(JsusFx_Sections &sections);
 
 public:
-	static const int kNumSamples = 64;
+	static const int kMaxSamples = 64;
 	
     NSEEL_VMCTX m_vm;
     Slider sliders[64];
@@ -256,8 +256,9 @@ public:
     EEL_F *tempo, *play_state, *play_position, *beat_position, *ts_num, *ts_denom;
     EEL_F *ext_noinit, *ext_nodenorm, *pdc_delay, *pdc_bot_cd, *pdc_top_ch;
     EEL_F *srate, *num_ch, *samplesblock;
-    EEL_F *spl[kNumSamples], *trigger;
+    EEL_F *spl[kMaxSamples], *trigger;
     EEL_F dummyValue;
+    int numValidInputChannels;
 	
     JsusFxGfx *gfx;
     int gfx_w;
@@ -270,8 +271,8 @@ public:
     bool compile(JsusFxPathLibrary &pathLibrary, const std::string &path);
     void prepare(int sampleRate, int blockSize);
     void moveSlider(int idx, float value);
-    void process(float **input, float **output, int size);
-    void process64(double **input, double **output, int size);
+    void process(float **input, float **output, int size, int numInputChannels, int numOutputChannels);
+    void process64(double **input, double **output, int size, int numInputChannels, int numOutputChannels);
     void draw();
 	
     const char * getString(int index, WDL_FastString ** fs);

--- a/jsusfx_gfx.cpp
+++ b/jsusfx_gfx.cpp
@@ -410,9 +410,4 @@ void JsusFxGfx::init(NSEEL_VMCTX vm) {
 	
 	// todo
 	NSEEL_addfunc_varparm("gfx_getchar",1,NSEEL_PProc_THIS,&__stub);
-	
-	// Reaper
-	NSEEL_addfunc_varparm("slider_automate",1,NSEEL_PProc_THIS,&__stub);
-	NSEEL_addfunc_varparm("sliderchange",1,NSEEL_PProc_THIS,&__stub);
-	NSEEL_addfunc_varparm("slider",1,NSEEL_PProc_THIS,&__stub); // todo : support this syntax: slider(index) = x
 }

--- a/jsusfx_gfx.cpp
+++ b/jsusfx_gfx.cpp
@@ -366,6 +366,7 @@ void JsusFxGfx::init(NSEEL_VMCTX vm) {
 	
 	m_gfx_mode = NSEEL_VM_regvar(vm,"gfx_mode");
 	m_gfx_clear = NSEEL_VM_regvar(vm,"gfx_clear");
+	m_gfx_texth = NSEEL_VM_regvar(vm,"gfx_texth");
 	m_gfx_dest = NSEEL_VM_regvar(vm,"gfx_dest");
 	
 	m_mouse_x = NSEEL_VM_regvar(vm,"mouse_x");

--- a/jsusfx_gfx.cpp
+++ b/jsusfx_gfx.cpp
@@ -364,7 +364,9 @@ void JsusFxGfx::init(NSEEL_VMCTX vm) {
 	m_gfx_x = NSEEL_VM_regvar(vm,"gfx_x");
 	m_gfx_y = NSEEL_VM_regvar(vm,"gfx_y");
 	
+	m_gfx_mode = NSEEL_VM_regvar(vm,"gfx_mode");
 	m_gfx_clear = NSEEL_VM_regvar(vm,"gfx_clear");
+	m_gfx_dest = NSEEL_VM_regvar(vm,"gfx_dest");
 	
 	m_mouse_x = NSEEL_VM_regvar(vm,"mouse_x");
 	m_mouse_y = NSEEL_VM_regvar(vm,"mouse_y");

--- a/jsusfx_gfx.h
+++ b/jsusfx_gfx.h
@@ -41,6 +41,8 @@ struct JsusFxGfx {
 	
 	void init(NSEEL_VMCTX vm);
 	
+	virtual bool handleFile(int index, const char *filename) { return true; }
+	
 	virtual void setup(const int w, const int h) { };
 	
 	virtual void gfx_line(int np, EEL_F ** params) { }
@@ -78,12 +80,14 @@ struct JsusFxGfx {
 
 	virtual void gfx_blit(EEL_F img, EEL_F scale, EEL_F rotate) { }
 	virtual void gfx_blitext(EEL_F img, EEL_F * coords, EEL_F angle) { }
-	virtual void gfx_blitext2(int mp, EEL_F ** params, int mode) { } // 0=blit, 1=deltablit
+	virtual void gfx_blitext2(int mp, EEL_F ** params, int blitmode) { } // 0=blit, 1=deltablit
 };
 
 #define GFXLOG printf("%s called!\n", __FUNCTION__)
 
 struct JsusFxGfx_Log : JsusFxGfx {
+	virtual bool handleFile(int index, const char *filename) override { GFXLOG; return true; }
+	
 	virtual void gfx_line(int np, EEL_F ** params) override { GFXLOG; }
 	virtual void gfx_rect(int np, EEL_F ** params) override { GFXLOG; }
 	virtual void gfx_circle(EEL_F x, EEL_F y, EEL_F radius, bool fill, bool aa) override { GFXLOG; }
@@ -105,7 +109,7 @@ struct JsusFxGfx_Log : JsusFxGfx {
 	virtual void gfx_setpixel(EEL_F r, EEL_F g, EEL_F b) override { GFXLOG; }
 	virtual void gfx_getpixel(EEL_F * r, EEL_F * g, EEL_F * b) override { GFXLOG; }
 
-	virtual EEL_F gfx_loadimg(void * opaque, int img, EEL_F loadFrom) override { GFXLOG; return 0.f; }
+	virtual EEL_F gfx_loadimg(void * opaque, int img, EEL_F loadFrom) override { GFXLOG; return -1.f; }
 	virtual void gfx_getimgdim(EEL_F img, EEL_F * w, EEL_F * h) override { GFXLOG; }
 	virtual EEL_F gfx_setimgdim(int img, EEL_F * w, EEL_F * h) override { GFXLOG; return 0.f; }
 	
@@ -119,7 +123,7 @@ struct JsusFxGfx_Log : JsusFxGfx {
 
 	virtual void gfx_blit(EEL_F img, EEL_F scale, EEL_F rotate) override { GFXLOG; }
 	virtual void gfx_blitext(EEL_F img, EEL_F * coords, EEL_F angle) override { GFXLOG; }
-	virtual void gfx_blitext2(int mp, EEL_F ** params, int mode) override { GFXLOG; }
+	virtual void gfx_blitext2(int mp, EEL_F ** params, int blitmode) override { GFXLOG; }
 };
 
 #undef GFXLOG

--- a/jsusfx_gfx.h
+++ b/jsusfx_gfx.h
@@ -30,10 +30,10 @@ struct JsusFxGfx {
 	EEL_F *m_gfx_x;
 	EEL_F *m_gfx_y;
 	
-	//EEL_F *m_gfx_mode;
+	EEL_F *m_gfx_mode;
 	EEL_F *m_gfx_clear;
 	//EEL_F *m_gfx_texth;
-	//EEL_F *m_gfx_dest;
+	EEL_F *m_gfx_dest;
 	
 	EEL_F *m_mouse_x;
 	EEL_F *m_mouse_y;

--- a/jsusfx_gfx.h
+++ b/jsusfx_gfx.h
@@ -32,7 +32,7 @@ struct JsusFxGfx {
 	
 	EEL_F *m_gfx_mode;
 	EEL_F *m_gfx_clear;
-	//EEL_F *m_gfx_texth;
+	EEL_F *m_gfx_texth;
 	EEL_F *m_gfx_dest;
 	
 	EEL_F *m_mouse_x;

--- a/max/jsusfx_max.cpp
+++ b/max/jsusfx_max.cpp
@@ -71,7 +71,7 @@ void jsusfx_describe(t_jsusfx *x) {
     post("jsusfx~ script %s : %s", x->scriptname, x->fx->desc);
     for(int i=0;i<64;i++) {
         if ( x->fx->sliders[i].exists ) {
-            Slider *s = &(x->fx->sliders[i]);
+            JsusFx_Slider *s = &(x->fx->sliders[i]);
             post(" slider%d: %g %g %s", i, s->min, s->max, s->desc);
             
             t_atom argv[5];

--- a/max/jsusfx_max.cpp
+++ b/max/jsusfx_max.cpp
@@ -282,7 +282,7 @@ void jsusfx_perform64(t_jsusfx *x, t_object *dsp64, double **ins, long numins, d
     if ( critical_tryenter(x->critical) )
         goto bypass;
 
-    x->fx->process64(inv, outs, sampleframes);
+    x->fx->process64(inv, outs, sampleframes, 2, 2);
     
     critical_exit(x->critical);
     return;

--- a/pd/jsusfx_pd.cpp
+++ b/pd/jsusfx_pd.cpp
@@ -171,7 +171,7 @@ t_int *jsusfx_perform(t_int *w) {
             outs[1][i] = ins[1][i];
         }
     } else {
-        x->fx->process(ins, outs, n);
+        x->fx->process(ins, outs, n, 2, 2);
         x->fx->dspLock.Leave();
     }
 

--- a/pd/jsusfx_pd.cpp
+++ b/pd/jsusfx_pd.cpp
@@ -70,7 +70,7 @@ void jsusfx_describe(t_jsusfx *x) {
     post("jsusfx~ script %s : %s", x->scriptpath, x->fx->desc);
     for(int i=0;i<64;i++) {
         if ( x->fx->sliders[i].exists ) {
-            Slider *s = &(x->fx->sliders[i]);
+            JsusFx_Slider *s = &(x->fx->sliders[i]);
             if ( s->inc == 0 )
                 post(" slider%d: %g %g %s [%g]", i, s->min, s->max, s->desc, *(s->owner));
             else

--- a/test/jsusfx_test.cpp
+++ b/test/jsusfx_test.cpp
@@ -114,7 +114,7 @@ void test_script(const char *path) {
 #endif
 
 	fx->prepare(44100, 64);
-	fx->process(in, out, 64);
+	fx->process(in, out, 64, 2, 2);
 
 #if ENABLE_INOUT_TEST
 	for (int i = 0; i < 64; ++i) {


### PR DESCRIPTION
Hi,

I added support for a few missing things. With these things in place, I managed to load most scripts I tried. I updated the Pd and Max code, but not able to test these myself, sadly. You may want to make use of the new slider name parsing and enumeration names in Max/Pd. Here's a run down of the changes,

- Added support for parsing extended slider definitions.
	- Slider names, and exposing those names to script.
	- Enumeration and enumeration value names.
- Added stubs for functions such as slider_automate, sliderchange.
- Added support for spl(channelIndex).
- Added support for up to 64 input/output channels.
- Added channel count argument to process and process64.
- Updated Pd, Max and test to pass input/output count to process/process64.

Regards,
Marcel