### PR TITLE
Fix the build on MinGW x64

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.2)
 
 project(jsusfx)
 option(PORTABLE "build a portable eel2")
@@ -44,19 +44,30 @@ if (UNIX AND NOT APPLE)
 			add_library(jsusfx ${sources} ${headers})
 		endif()
 	endif()
+elseif (MINGW)
+		# MinGW x64
+		if ((NOT PORTABLE) AND (CMAKE_SIZEOF_VOID_P EQUAL 8))
+			add_custom_command(
+				OUTPUT ${PROJECT_SOURCE_DIR}/WDL/eel2/asm-nseel-x64.obj
+				COMMAND php a2x64.php win64
+				WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/WDL/eel2
+			)
+			add_library(jsusfx ${sources} ${headers} ${PROJECT_SOURCE_DIR}/WDL/eel2/asm-nseel-x64.obj)
+		else()
+			# MinGW i686
+			add_library(jsusfx ${sources} ${headers})
+		endif()
+elseif (PORTABLE OR WIN32)
+	add_library(jsusfx ${sources} ${headers})
 else()
-	if (PORTABLE OR WIN32)
-		add_library(jsusfx ${sources} ${headers})
-	else()
-		# MacOS, 64-bit always
-		add_custom_command(
-			OUTPUT ${PROJECT_SOURCE_DIR}/WDL/eel2/asm-nseel-x64-macho.o
-			COMMAND php a2x64.php macho64x
-			DEPENDS ${PROJECT_SOURCE_DIR}/WDL/eel2/asm-nseel-x86-gcc.c
-			WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/WDL/eel2
-		)
-		add_library(jsusfx ${sources} ${headers} ${PROJECT_SOURCE_DIR}/WDL/eel2/asm-nseel-x64-macho.o)
-	endif()
+	# MacOS, 64-bit always
+	add_custom_command(
+		OUTPUT ${PROJECT_SOURCE_DIR}/WDL/eel2/asm-nseel-x64-macho.o
+		COMMAND php a2x64.php macho64x
+		DEPENDS ${PROJECT_SOURCE_DIR}/WDL/eel2/asm-nseel-x86-gcc.c
+		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/WDL/eel2
+	)
+	add_library(jsusfx ${sources} ${headers} ${PROJECT_SOURCE_DIR}/WDL/eel2/asm-nseel-x64-macho.o)
 endif()
 
 target_compile_definitions(jsusfx PUBLIC WDL_FFT_REALSIZE=8)

--- a/src/WDL/eel2/nseel-cfunc.c
+++ b/src/WDL/eel2/nseel-cfunc.c
@@ -153,7 +153,7 @@ EEL_F NSEEL_CGEN_CALL nseel_int_rand(EEL_F f)
         }
       }
     #endif
-  #elif !defined(__LP64__)
+  #elif !(defined(_WIN64) || defined(__LP64__))
     #define FUNCTION_MARKER "\n.byte 0x89,0x90,0x90,0x90,0x90,0x90,0x90,0x90,0x90,0x90,0x90,0x90\n"
     #include "asm-nseel-x86-gcc.c"
     void eel_setfp_round()


### PR DESCRIPTION
Expected to fix #34. Not actually tested, but it builds.

- the definition `__LP64__` is not sufficient to check for 64-bit, because MinGW does not have it;
  it's edited to support the MinGW case, as seen in other places.
- adapt CMake to build with nasm in case of MinGW (uses variable `MINGW`, added in CMake 3.2)
