### PR TITLE
use pd_error() instead of error()

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.git*      	export-ignore
+.travis.yml	export-ignore


### PR DESCRIPTION
- use `pd_error()` instead of the deprecated `error()` (which was removed from Pd's public API due to numerous nameclashes with 3rd party libraries) - Closes #38 
- also exclude VCS-configuration from exported tarballs (as this makes troubles if you import a jsusfx-release into a repository (as is common e.g. for packaging in Linux distributions)